### PR TITLE
Made updates to enable CORS

### DIFF
--- a/nacho_api/settings.py
+++ b/nacho_api/settings.py
@@ -39,6 +39,7 @@ INSTALLED_APPS = (
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
+    'corsheaders',
     'rest_framework',
     'nacho',
 )
@@ -51,6 +52,8 @@ MIDDLEWARE_CLASSES = (
     'django.contrib.auth.middleware.SessionAuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
+    'corsheaders.middleware.CorsMiddleware',
+    'django.middleware.common.CommonMiddleware',
 )
 
 ROOT_URLCONF = 'nacho_api.urls'
@@ -81,6 +84,9 @@ USE_L10N = True
 
 USE_TZ = True
 
+# CORS
+# https://github.com/ottoyiu/django-cors-headers
+CORS_ORIGIN_ALLOW_ALL = True
 
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/1.7/howto/static-files/

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,10 +2,11 @@ Django==1.7.3
 argparse==1.2.1
 dj-database-url==0.3.0
 dj-static==0.0.6
+django-cors-headers==1.0.0
 djangorestframework==3.0.3
+gunicorn==19.2.1
 httpie==0.8.0
 requests==2.5.1
 static3==0.5.1
 wsgiref==0.1.2
-gunicorn==19.1.1
 psycopg2==2.5.1


### PR DESCRIPTION
Traditionally, javascript applications could only load content from the same domain that they're hosted on. This means that if our front-end app and backend API are on different domains (for example, for testing locally), the app won't be able to get to the data.

CORS allows javascript applications from anywhere to make these requests. This might have some security ramifications to look into later. We can whitelist just certain domains, or allow only certain HTTP methods (e.g. `GET` but not `POST`).

See https://developer.mozilla.org/en-US/docs/Web/HTTP/Access_control_CORS

Using this library: https://github.com/ottoyiu/django-cors-headers
